### PR TITLE
Add error threshold input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Typecheck
-        uses: gozala/typescript-error-reporter-action@v1.0.5
+        uses: computerjazz/typescript-error-reporter-action@v1.0.9
 ```
 
 `tsconfig.json`:
@@ -52,13 +52,23 @@ jobs:
 
 ## Passing `project` parameter
 
-If your working with a monorepo or your `tsconfig.json` is not in the root repo,
+If you're working with a monorepo or your `tsconfig.json` is not in the root repo,
 or you use different config file, you can provide a `project` parmeter with a
 path to the repo itself:
 
 ```yaml
 - name: Typecheck
-  uses: gozala/typescript-error-reporter-action@v1.0.5
+  uses: computerjazz/typescript-error-reporter-action@v1.0.9
   with:
     project: packages/subpackage/tsconfig.json
+```
+## Passing `error_fail_threshold` parameter
+
+If you're incrementally adopting typescript in a project, you may not want to fail the entire workflow on a single typescript error. `error_fail_threshold` allows you to pass the maximum number of errors at which the step passes. Defaults to 0:
+
+```yaml
+- name: Typecheck
+  uses: computerjazz/typescript-error-reporter-action@v1.0.9
+  with:
+    error_fail_threshold: 100
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Typecheck
-        uses: gozala/typescript-error-reporter-action@v1.0.9
+        uses: gozala/typescript-error-reporter-action@v1.0.5
 ```
 
 `tsconfig.json`:
@@ -58,7 +58,7 @@ path to the repo itself:
 
 ```yaml
 - name: Typecheck
-  uses: gozala/typescript-error-reporter-action@v1.0.9
+  uses: gozala/typescript-error-reporter-action@v1.0.5
   with:
     project: packages/subpackage/tsconfig.json
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Typecheck
-        uses: computerjazz/typescript-error-reporter-action@v1.0.9
+        uses: gozala/typescript-error-reporter-action@v1.0.9
 ```
 
 `tsconfig.json`:
@@ -58,7 +58,7 @@ path to the repo itself:
 
 ```yaml
 - name: Typecheck
-  uses: computerjazz/typescript-error-reporter-action@v1.0.9
+  uses: gozala/typescript-error-reporter-action@v1.0.9
   with:
     project: packages/subpackage/tsconfig.json
 ```
@@ -68,7 +68,7 @@ If you're incrementally adopting typescript in a project, you may not want to fa
 
 ```yaml
 - name: Typecheck
-  uses: computerjazz/typescript-error-reporter-action@v1.0.9
+  uses: gozala/typescript-error-reporter-action@v1.0.9
   with:
     error_fail_threshold: 100
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,3 +11,7 @@ inputs:
   project:
     description: 'Optional project path.'
     required: false
+  error_fail_threshold:
+    description: 'Optional number of errors threshold at which this step fails.'
+    required: false
+  

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,12 @@ const typecheck = (projectPath:string) => {
     ? performIncrementalCompilation(ts, projectPath)
     : performCompilation(ts, config)
 
-  if (errors > 0) {
-    setFailed(`Found ${errors} errors!`)
+  
+  const errThreshold = Number(getInput('error_fail_threshold') || 0)
+  const logString = `Found ${errors} errors!`
+  console.log(logString)
+  if (errors > errThreshold) {
+    setFailed(logString)
   }
 }
 


### PR DESCRIPTION
Allows user to designate a threshold for the number of typescript errors that may occur and the step will still pass (defaults to 0 errors). Useful for projects that are incrementally adopting typescript.